### PR TITLE
Removes 'virtual' from deleted assignment operator

### DIFF
--- a/includes/fc4sc_covergroup.hpp
+++ b/includes/fc4sc_covergroup.hpp
@@ -105,7 +105,7 @@ protected:
   /*! Disabled */
   covergroup() = delete;
   /*! Disabled */
-  virtual covergroup &operator=(const covergroup &other) = delete;
+  covergroup &operator=(const covergroup &other) = delete;
   /*! Disabled */
   covergroup(const covergroup &other) = delete;
   /*! Disabled */


### PR DESCRIPTION
Some MacOS Clang users report compilation fails on this with:

  Undefined symbols for architecture x86_64:
    "___cxa_deleted_virtual"