### PR TITLE
fixes UCIS schema compatibility

### DIFF
--- a/includes/fc4sc_base.hpp
+++ b/includes/fc4sc_base.hpp
@@ -242,6 +242,8 @@ public:
   /*! Number of sample misses (no bin hit)*/
   uint64_t misses = 0;
 
+  virtual size_t size() = 0;
+
   /*! Destructor */
   virtual ~cvp_base(){}
 };

--- a/includes/fc4sc_base.hpp
+++ b/includes/fc4sc_base.hpp
@@ -242,7 +242,7 @@ public:
   /*! Number of sample misses (no bin hit)*/
   uint64_t misses = 0;
 
-  virtual size_t size() = 0;
+  virtual size_t size() const = 0;
 
   /*! Destructor */
   virtual ~cvp_base(){}

--- a/includes/fc4sc_bin.hpp
+++ b/includes/fc4sc_bin.hpp
@@ -192,7 +192,7 @@ public:
   virtual void to_xml(std::ostream &stream) const
   {
     stream << "<ucis:coverpointBin name=\"" << fc4sc::global::escape_xml_chars(name) << "\" \n";
-    stream << "key=\"" << fc4sc::global::escape_xml_chars(name) << "\"\n";
+    stream << "key=\"cpb_" << fc4sc::global::get_next_key() << "\"\n";
     stream << "type=\""
            << this->ucis_bin_type
            << "\" "

--- a/includes/fc4sc_bin.hpp
+++ b/includes/fc4sc_bin.hpp
@@ -192,6 +192,7 @@ public:
   virtual void to_xml(std::ostream &stream) const
   {
     stream << "<ucis:coverpointBin name=\"" << fc4sc::global::escape_xml_chars(name) << "\" \n";
+    stream << "key=\"" << fc4sc::global::escape_xml_chars(name) << "\"\n";
     stream << "type=\""
            << this->ucis_bin_type
            << "\" "

--- a/includes/fc4sc_covergroup.hpp
+++ b/includes/fc4sc_covergroup.hpp
@@ -246,7 +246,7 @@ public:
            << "\" line=\""
            << "1"
            << "\" inlineCount=\"1\"/>\n";
-    stream << "<ucis:cgSourceId file=\"" << file_name << "\" "
+    stream << "<ucis:cgSourceId file=\"" << fc4sc::global::get_xml_filename_id(file_name) << "\" "
            << "line=\"" << line << "\""
            << " inlineCount=\"1\"/>\n";
     stream << "</ucis:cgId>\n";

--- a/includes/fc4sc_coverpoint.hpp
+++ b/includes/fc4sc_coverpoint.hpp
@@ -386,9 +386,7 @@ public:
   {
     stream << "<ucis:coverpoint ";
     stream << "name=\"" << fc4sc::global::escape_xml_chars(this->name) << "\" ";
-    stream << "key=\""
-           << "KEY"
-           << "\" ";
+    stream << "key=\"cp_" << fc4sc::global::get_next_key() << "\" ";
     stream << "exprString=\"" << fc4sc::global::escape_xml_chars(this->sample_expression_str) << "\"";
     stream << ">\n";
 

--- a/includes/fc4sc_coverpoint.hpp
+++ b/includes/fc4sc_coverpoint.hpp
@@ -269,7 +269,7 @@ public:
   /*!
    *  Retrieves the number of regular bins
    */
-  uint64_t size() {
+  size_t size() override {
     return bins.size();
   }
 

--- a/includes/fc4sc_coverpoint.hpp
+++ b/includes/fc4sc_coverpoint.hpp
@@ -269,7 +269,7 @@ public:
   /*!
    *  Retrieves the number of regular bins
    */
-  size_t size() override {
+  size_t size() const override {
     return bins.size();
   }
 

--- a/includes/fc4sc_cross.hpp
+++ b/includes/fc4sc_cross.hpp
@@ -260,7 +260,7 @@ public:
 
     stream << "<ucis:cross ";
     stream << "name=\"" << fc4sc::global::escape_xml_chars(this->name) << "\" ";
-    stream << "key=\"" << fc4sc::global::escape_xml_chars(this->name) << "\" ";
+    stream << "key=\"cr_" << fc4sc::global::get_next_key() << "\" ";
     stream << ">\n";
 
     stream << "<ucis:options ";
@@ -291,7 +291,7 @@ public:
       stream << "name=\""
              << ss.str()
              << "\"  \n";
-      stream << "key=\"" << ss.str() << "\" \n";
+      stream << "key=\"crb_" << fc4sc::global::get_next_key() << "\" \n";
       stream << "type=\""
              << "default"
              << "\" \n";

--- a/includes/fc4sc_cross.hpp
+++ b/includes/fc4sc_cross.hpp
@@ -80,9 +80,11 @@ class cross : public cvp_base
     return 1;
   }
 
-  size_t size() override
+  size_t size() const override
   {
-    return std::accumulate(std::begin(cvps_vec), std::end(cvps_vec), 1);
+    size_t prod = 1;
+    for(auto& cvp: cvps_vec) prod *= cvp->size();
+    return prod;
   }
 
   /*!
@@ -162,8 +164,7 @@ public:
     std::reverse(cvps_vec.begin(), cvps_vec.end());
     std::vector<size_t> prod;
     prod.reserve(cvps_vec.size());
-    for(auto& cvp: cvps_vec)
-        init_bins(prod);
+    init_bins(prod);
 
   };
   

--- a/includes/fc4sc_cross.hpp
+++ b/includes/fc4sc_cross.hpp
@@ -260,12 +260,16 @@ public:
 
     stream << "<ucis:cross ";
     stream << "name=\"" << fc4sc::global::escape_xml_chars(this->name) << "\" ";
-    stream << "key=\""
-           << "KEY"
-           << "\" ";
+    stream << "key=\"" << fc4sc::global::escape_xml_chars(this->name) << "\" ";
     stream << ">\n";
 
-    stream << option << "\n";
+    stream << "<ucis:options ";
+    stream << "weight=\"" << option.weight << "\" ";
+    stream << "goal=\"" << option.goal << "\" ";
+    stream << "comment=\"" << option.comment << "\" ";
+    stream << "at_least=\"" << option.at_least << "\" ";
+    stream << "cross_num_print_missing =\"" << 0 << "\" ";
+    stream << "/>\n";
 
     for (auto &cvp : cvps_vec)
     {

--- a/includes/fc4sc_cross.hpp
+++ b/includes/fc4sc_cross.hpp
@@ -276,13 +276,22 @@ public:
       stream << "<ucis:crossExpr>" << cvp->name << "</ucis:crossExpr> \n";
     }
 
+    std::ostringstream ss;
     for (auto& bin : bins)
     {
+      ss.str("");
+      auto it = bin.first.begin();
+      for (auto& cvp : cvps_vec) {
+        if(ss.str().size()) ss<<"/";
+          ss<<cvp->name<<"["<< *it<<"]";
+          it++;
+      }
+
       stream << "<ucis:crossBin \n";
       stream << "name=\""
-             << ""
+             << ss.str()
              << "\"  \n";
-      stream << "key=\"" << 0 << "\" \n";
+      stream << "key=\"" << ss.str() << "\" \n";
       stream << "type=\""
              << "default"
              << "\" \n";

--- a/includes/fc4sc_cross.hpp
+++ b/includes/fc4sc_cross.hpp
@@ -80,6 +80,11 @@ class cross : public cvp_base
     return 1;
   }
 
+  size_t size() override
+  {
+    return std::accumulate(std::begin(cvps_vec), std::end(cvps_vec), 1);
+  }
+
   /*!
    *  \brief Helper function to check if a sampled value is in a cross
    *  \tparam k Index of the currently checked element
@@ -121,6 +126,19 @@ class cross : public cvp_base
     return true;
   }
 
+  void init_bins(std::vector<size_t>& indices, size_t cvp_index=0){
+      if(cvp_index==cvps_vec.size())
+          bins[indices]=0;
+      else {
+          auto& cvp = cvps_vec[cvp_index];
+          for(size_t i=0; i<cvp->size(); ++i){
+              indices.push_back(i);
+              init_bins(indices, cvp_index+1);
+              indices.pop_back();
+          }
+      }
+  };
+
 public:
   /*! Hit cross bins storage */
   std::map<std::vector<size_t>, uint64_t> bins;
@@ -142,8 +160,12 @@ public:
     cvps_vec = std::vector<cvp_base*>{args...};
 
     std::reverse(cvps_vec.begin(), cvps_vec.end());
-  };
+    std::vector<size_t> prod;
+    prod.reserve(cvps_vec.size());
+    for(auto& cvp: cvps_vec)
+        init_bins(prod);
 
+  };
   
   template <typename... Restrictions, typename Select>
   cross(binsof<Select> binsof_inst,  Restrictions... binsofs) : cross (binsofs...) {

--- a/includes/fc4sc_master.hpp
+++ b/includes/fc4sc_master.hpp
@@ -556,7 +556,7 @@ public:
   }
 
   static uint64_t get_next_key(bool reset=false){
-      uint64_t key{0};
+      static uint64_t key{0};
       if(reset){
           key=0;
           return 0;

--- a/includes/fc4sc_master.hpp
+++ b/includes/fc4sc_master.hpp
@@ -257,8 +257,6 @@ class global
       stream << ">\n";
       stream << "</ucis:historyNodes>\n";
 
-      static int key = 0;
-
       // Each type is between an instanceCoverages tag
       for (auto &type_it : cv_data)
       {
@@ -267,8 +265,8 @@ class global
         stream << "name=\""
                << "string"
                << "\" \n";
-        stream << "key=\"" << ++key << "\" \n";
-        stream << "instanceId=\"" << ++key << "\" \n";
+        stream << "key=\"ic_" << fc4sc::global::get_next_key() << "\" \n";
+        stream << "instanceId=\"" << get_next_key() << "\" \n";
         stream << "alias=\""
                << "string"
                << "\" \n";
@@ -295,7 +293,7 @@ class global
           stream << "<ucis:cgInstance ";
           stream << "name=\"" << type_it.second.cvg_insts_name[i] << "\" \n";
 
-          stream << "key=\"" << ++key << "\" \n";
+          stream << "key=\"cgi_" << fc4sc::global::get_next_key() << "\" \n";
           stream << "alias=\""
                  << "string"
                  << "\" \n";
@@ -317,7 +315,7 @@ class global
 
       stream << "</ucis:UCIS>\n";
 
-      key = 0;
+      get_next_key(true);
       return stream;
     };
 
@@ -555,6 +553,15 @@ public:
       if(filename2id.find(n) == std::end(filename2id))
           filename2id[n] = filename2id.size()+1;
       return filename2id[n];
+  }
+
+  static uint64_t get_next_key(bool reset=false){
+      uint64_t key{0};
+      if(reset){
+          key=0;
+          return 0;
+      } else
+          return ++key;
   }
 };
 

--- a/includes/fc4sc_master.hpp
+++ b/includes/fc4sc_master.hpp
@@ -170,15 +170,19 @@ class global
              << "\"";
       stream << ">\n";
 
-      // Needed information but not filled
-      stream << "<ucis:sourceFiles ";
-      stream << " fileName=\""
-             << "string"
-             << "\"";
-      stream << " id=\""
-             << "201"
-             << "\" ";
-      stream << "/>\n";
+      std::unordered_map<std::string, size_t> filename2id;
+      for (auto &type_it : cv_data)
+          if(filename2id.find(type_it.second.file_name) == std::end(filename2id)) {
+              filename2id[type_it.second.file_name] = filename2id.size()+1;
+              stream << "<ucis:sourceFiles ";
+              stream << " fileName=\""
+                      << type_it.second.file_name
+                      << "\"";
+              stream << " id=\""
+                      << filename2id.size()
+                      << "\" ";
+              stream << "/>\n";
+         }
 
       // Needed information but not filled
       stream << "<ucis:historyNodes ";
@@ -273,7 +277,7 @@ class global
         stream << ">\n";
 
         stream << "<ucis:id ";
-        stream << "file=\"" << type_it.second.file_name << "\" ";
+        stream << "file=\"" << filename2id[type_it.second.file_name] << "\" ";
         stream << "line=\"" << type_it.second.line << "\" ";
         stream << "inlineCount=\""
                << "1"
@@ -544,6 +548,13 @@ public:
       }
     }
     return out;
+  }
+
+  static unsigned get_xml_filename_id(const std::string& n){
+      static std::unordered_map<std::string, size_t> filename2id;
+      if(filename2id.find(n) == std::end(filename2id))
+          filename2id[n] = filename2id.size()+1;
+      return filename2id[n];
   }
 };
 

--- a/includes/fc4sc_options.hpp
+++ b/includes/fc4sc_options.hpp
@@ -100,10 +100,10 @@ struct cvg_option
     stream << "comment=\"" << inst.comment << "\" ";
     stream << "at_least=\"" << inst.at_least << "\" ";
     stream << "auto_bin_max=\"" << inst.auto_bin_max << "\" ";
-    stream << "detect_overlap=\"" << inst.detect_overlap << "\" ";
+    stream << "detect_overlap=\"" << (inst.detect_overlap?"true":"false") << "\" ";
     stream << "cross_num_print_missing=\"" << inst.cross_num_print_missing << "\" ";
-    stream << "per_instance=\"" << inst.per_instance << "\" ";
-    stream << "merge_instances=\"" << inst.merge_instances << "\" ";
+    stream << "per_instance=\"" << (inst.per_instance?"true":"false") << "\" ";
+    stream << "merge_instances=\"" << (inst.merge_instances?"true":"false") << "\" ";
     stream << "/>";
     return stream;
   }

--- a/includes/fc4sc_options.hpp
+++ b/includes/fc4sc_options.hpp
@@ -66,6 +66,9 @@ struct cvg_option
   /*! !UNIPLEMENTED! Collect coverage per instance */
   bool per_instance;
 
+  /*! !UNIPLEMENTED! Collect coverage per instance */
+  bool merge_instances;
+
   /*! !UNIPLEMENTED! Enables covergroup::get_inst_coverage() */
   bool get_inst_coverage;
 
@@ -82,6 +85,7 @@ struct cvg_option
 
     this->cross_num_print_missing = 0;
     this->per_instance = 0;
+    this->merge_instances = 0;
     this->get_inst_coverage = 0;
   }
 
@@ -99,6 +103,7 @@ struct cvg_option
     stream << "detect_overlap=\"" << inst.detect_overlap << "\" ";
     stream << "cross_num_print_missing=\"" << inst.cross_num_print_missing << "\" ";
     stream << "per_instance=\"" << inst.per_instance << "\" ";
+    stream << "merge_instances=\"" << inst.merge_instances << "\" ";
     stream << "/>";
     return stream;
   }


### PR DESCRIPTION
When using the generated XML with [pyucis ](https://github.com/fvutils/pyucis) the reading fails as pyucis does a XSD schema validation using the XSD schema of the 'Unified Coverage Interoperability Standard (UCIS) Version 1.0'.
This pull request provides fixes to make the XML schema compliant.